### PR TITLE
Use netcoreapp3.1 for backward-compatible testing

### DIFF
--- a/azure-pipelines-e2e-tests-template.yml
+++ b/azure-pipelines-e2e-tests-template.yml
@@ -58,6 +58,7 @@ stages:
 
         - pwsh: |
             $framework = "net6.0"
+            $backwardCompatibleFramework = "netcoreapp3.1"
 
             if ($env:AGENT_OS -eq 'Windows_NT') {
               $runtimeIdentifier = "win-x64"
@@ -72,7 +73,7 @@ stages:
 
             $backwardCompatibleRelease = "${{ parameters.backwardCompatibleRelease }}"
             echo "##vso[task.setvariable variable=BACKWARD_COMPATIBLE_DOTNET_WORKER_DIR]$(Build.BinariesDirectory)${pathSeparator}Microsoft.Spark.Worker-${backwardCompatibleRelease}"
-            echo "##vso[task.setvariable variable=BACKWARD_COMPATIBLE_WORKER_URL]https://github.com/dotnet/spark/releases/download/v${backwardCompatibleRelease}/Microsoft.Spark.Worker.${framework}.${runtimeIdentifier}-${backwardCompatibleRelease}.zip"
+            echo "##vso[task.setvariable variable=BACKWARD_COMPATIBLE_WORKER_URL]https://github.com/dotnet/spark/releases/download/v${backwardCompatibleRelease}/Microsoft.Spark.Worker.${backwardCompatibleFramework}.${runtimeIdentifier}-${backwardCompatibleRelease}.zip"
 
             $dotnetWorkerDir = "${artifactPath}${pathSeparator}Microsoft.Spark.Worker${pathSeparator}${framework}${pathSeparator}${runtimeIdentifier}"
             echo "##vso[task.setvariable variable=CURRENT_DOTNET_WORKER_DIR]$dotnetWorkerDir"


### PR DESCRIPTION
This is just a temporary fix to prove the hypothesis. Previous releases were all published with netcoreapp3.1 so need to be resolved with that rather than net6.0. A proper fix probably involves testing the URL, or listing the release artefacts.